### PR TITLE
REPO-5391 : [cmis webservices] isPrivateWorkingCopy throws NullPointerException

### DIFF
--- a/src/main/java/org/alfresco/cmis/dsl/CmisAssertion.java
+++ b/src/main/java/org/alfresco/cmis/dsl/CmisAssertion.java
@@ -315,18 +315,20 @@ public class CmisAssertion extends DSLAssertion<CmisWrapper>
     {
         Document document = cmisAPI().withCMISUtil().getCmisDocument(cmisAPI().getLastResource());
         STEP(String.format("%s Verify if document '%s' is private working copy", CmisWrapper.STEP_PREFIX, document.getName()));
-        if (BindingType.WEBSERVICES.equals(cmisAPI().getSession().getBinding().getBindingType()))
-        {
-            // Alfresco supports BindingType.WEBSERVICES for CMIS 1.0 and
-            // "cmis:isPrivateWorkingCopy" was introduced with CMIS 1.1
-            // thus checking if the document is a pwc through CMIS 1.0 method
-            // https://chemistry.apache.org/java/javadoc/org/apache/chemistry/opencmis/client/api/Document.html#isVersionSeriesPrivateWorkingCopy--
-            Assert.assertTrue(cmisAPI().withCMISUtil().isVersionSeriesPrivateWorkingCopy());
-        }
-        else
-        {
-            Assert.assertTrue(cmisAPI().withCMISUtil().isPrivateWorkingCopy());
-        }
+
+        // Alfresco supports BindingType.WEBSERVICES for CMIS 1.0
+        // (BindingType.ATOMPUB and BindingType.BROWSER for CMIS 1.1)
+        // and "cmis:isPrivateWorkingCopy" was introduced with CMIS 1.1.
+        //
+        // Checking if the document is a pwc through
+        // https://chemistry.apache.org/java/javadoc/org/apache/chemistry/opencmis/client/api/DocumentProperties.html#isPrivateWorkingCopy--
+        // won't work for BindingType.WEBSERVICES
+        //
+        // Thus using
+        // https://chemistry.apache.org/java/javadoc/org/apache/chemistry/opencmis/client/api/Document.html#isVersionSeriesPrivateWorkingCopy--
+        // which is supported in all CMIS versions.
+        Assert.assertTrue(cmisAPI().withCMISUtil().isVersionSeriesPrivateWorkingCopy());
+
         return cmisAPI();
     }
 
@@ -339,7 +341,7 @@ public class CmisAssertion extends DSLAssertion<CmisWrapper>
     {
         Document document = cmisAPI().withCMISUtil().getCmisDocument(cmisAPI().getLastResource());
         STEP(String.format("%s Verify if document '%s' PWC is not private working copy", CmisWrapper.STEP_PREFIX, document.getName()));
-        Assert.assertFalse(cmisAPI().withCMISUtil().isPrivateWorkingCopy());
+        Assert.assertFalse(cmisAPI().withCMISUtil().isVersionSeriesPrivateWorkingCopy());
         return cmisAPI();
     }
 

--- a/src/main/java/org/alfresco/cmis/dsl/CmisAssertion.java
+++ b/src/main/java/org/alfresco/cmis/dsl/CmisAssertion.java
@@ -37,6 +37,7 @@ import org.apache.chemistry.opencmis.commons.data.Ace;
 import org.apache.chemistry.opencmis.commons.data.Acl;
 import org.apache.chemistry.opencmis.commons.data.CmisExtensionElement;
 import org.apache.chemistry.opencmis.commons.enums.Action;
+import org.apache.chemistry.opencmis.commons.enums.BindingType;
 import org.apache.chemistry.opencmis.commons.enums.ChangeType;
 import org.apache.chemistry.opencmis.commons.enums.ExtensionLevel;
 import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
@@ -314,7 +315,18 @@ public class CmisAssertion extends DSLAssertion<CmisWrapper>
     {
         Document document = cmisAPI().withCMISUtil().getCmisDocument(cmisAPI().getLastResource());
         STEP(String.format("%s Verify if document '%s' is private working copy", CmisWrapper.STEP_PREFIX, document.getName()));
-        Assert.assertTrue(cmisAPI().withCMISUtil().isPrivateWorkingCopy());
+        if (BindingType.WEBSERVICES.equals(cmisAPI().getSession().getBinding().getBindingType()))
+        {
+            // Alfresco supports BindingType.WEBSERVICES for CMIS 1.0 and
+            // "cmis:isPrivateWorkingCopy" was introduced with CMIS 1.1
+            // thus checking if the document is a pwc through CMIS 1.0 method
+            // https://chemistry.apache.org/java/javadoc/org/apache/chemistry/opencmis/client/api/Document.html#isVersionSeriesPrivateWorkingCopy--
+            Assert.assertTrue(cmisAPI().withCMISUtil().isVersionSeriesPrivateWorkingCopy());
+        }
+        else
+        {
+            Assert.assertTrue(cmisAPI().withCMISUtil().isPrivateWorkingCopy());
+        }
         return cmisAPI();
     }
 

--- a/src/main/java/org/alfresco/cmis/dsl/CmisAssertion.java
+++ b/src/main/java/org/alfresco/cmis/dsl/CmisAssertion.java
@@ -327,7 +327,7 @@ public class CmisAssertion extends DSLAssertion<CmisWrapper>
         // Thus using
         // https://chemistry.apache.org/java/javadoc/org/apache/chemistry/opencmis/client/api/Document.html#isVersionSeriesPrivateWorkingCopy--
         // which is supported in all CMIS versions.
-        Assert.assertTrue(cmisAPI().withCMISUtil().isVersionSeriesPrivateWorkingCopy());
+        Assert.assertTrue(cmisAPI().withCMISUtil().isPrivateWorkingCopy());
 
         return cmisAPI();
     }
@@ -341,7 +341,7 @@ public class CmisAssertion extends DSLAssertion<CmisWrapper>
     {
         Document document = cmisAPI().withCMISUtil().getCmisDocument(cmisAPI().getLastResource());
         STEP(String.format("%s Verify if document '%s' PWC is not private working copy", CmisWrapper.STEP_PREFIX, document.getName()));
-        Assert.assertFalse(cmisAPI().withCMISUtil().isVersionSeriesPrivateWorkingCopy());
+        Assert.assertFalse(cmisAPI().withCMISUtil().isPrivateWorkingCopy());
         return cmisAPI();
     }
 

--- a/src/main/java/org/alfresco/cmis/dsl/CmisUtil.java
+++ b/src/main/java/org/alfresco/cmis/dsl/CmisUtil.java
@@ -278,20 +278,6 @@ public class CmisUtil
         return newFolder;
     }
 
-    protected boolean isPrivateWorkingCopy()
-    {
-        boolean result = false;
-        try
-        {
-            result = getPWCDocument().isPrivateWorkingCopy();
-        }
-        catch (CmisVersioningException cmisVersioningException)
-        {
-            result = false;
-        }
-        return result;
-    }
-
     protected boolean isVersionSeriesPrivateWorkingCopy()
     {
         boolean result;

--- a/src/main/java/org/alfresco/cmis/dsl/CmisUtil.java
+++ b/src/main/java/org/alfresco/cmis/dsl/CmisUtil.java
@@ -292,6 +292,20 @@ public class CmisUtil
         return result;
     }
 
+    protected boolean isVersionSeriesPrivateWorkingCopy()
+    {
+        boolean result;
+        try
+        {
+            result = getPWCDocument().isVersionSeriesPrivateWorkingCopy();
+        }
+        catch (CmisVersioningException cmisVersioningException)
+        {
+            result = false;
+        }
+        return result;
+    }
+
     /**
      * Returns the PWC (private working copy) ID of the document version series
      */

--- a/src/main/java/org/alfresco/cmis/dsl/CmisUtil.java
+++ b/src/main/java/org/alfresco/cmis/dsl/CmisUtil.java
@@ -278,7 +278,7 @@ public class CmisUtil
         return newFolder;
     }
 
-    protected boolean isVersionSeriesPrivateWorkingCopy()
+    protected boolean isPrivateWorkingCopy()
     {
         boolean result;
         try


### PR DESCRIPTION
   - Alfresco supports **BindingType.WEBSERVICES for CMIS 1.0** and _"cmis:isPrivateWorkingCopy"_ was introduced with **CMIS 1.1** 
   - thus checking if the document is a pwc (private working copy) through CMIS 1.0 method https://chemistry.apache.org/java/javadoc/org/apache/chemistry/opencmis/client/api/Document.html#isVersionSeriesPrivateWorkingCopy--